### PR TITLE
Fix typo of radiant in shortcuts

### DIFF
--- a/doc/shortcuts
+++ b/doc/shortcuts
@@ -71,7 +71,7 @@ Ctrl-H	change to hexadecimal number base
 Ctrl-O	change to octal number base
 Ctrl-B	change to binary number base
 Ctrl-E	change to degree angle base
-Ctrl-R	change to radiant angle base
+Ctrl-R	change to radian angle base
 Ctrl-G	change to GRAD angle base
 Ctrl-A	change to (normal) algebraic notation
 Ctrl-N	change to Reverse Polish Notation (RPN)


### PR DESCRIPTION
I replaced radiant as angle base which means to emit light with radian which is the angle unit that has 2pi to go around the entire circle. 
